### PR TITLE
feat: keep modal open after saving retrospective item

### DIFF
--- a/app/views/retrospective_sessions/show.html.erb
+++ b/app/views/retrospective_sessions/show.html.erb
@@ -964,6 +964,20 @@ function resetForm() {
   document.getElementById('retrospective-form').reset();
 }
 
+function resetFormButKeepCategory() {
+  // Store the current category value
+  const categoryValue = document.getElementById('category').value;
+  
+  // Reset all fields
+  document.getElementById('name').value = '';
+  document.getElementById('person').value = '';
+  document.getElementById('comments').value = '';
+  document.getElementById('due_date').value = '';
+  
+  // Restore the category value
+  document.getElementById('category').value = categoryValue;
+}
+
 function addItemToColumn(item) {
   const categoryMap = {
     0: 'continue-column',    // continue
@@ -1158,7 +1172,8 @@ function submitForm(event) {
   })
   .then(data => {
     if (data.status === 'success') {
-      closeModal();
+      // Don't close modal, just reset fields but keep category
+      resetFormButKeepCategory();
       addItemToColumn(data.item);
       updateColumnCounters();
       showSuccessMessage();


### PR DESCRIPTION
Fixes #3

## Changes
- Modified submitForm() to not close modal after successful save
- Added resetFormButKeepCategory() function to clear all fields except category
- Category field now persists with last selected value for easy consecutive entries

## Testing
The modal will now:
1. Stay open after clicking "Save"
2. Clear all form fields (name, person, comments, due date)
3. Keep the category dropdown value from the last saved item

Generated with [Claude Code](https://claude.ai/code)